### PR TITLE
Automatic fixes of clang-tidy warnings: misc-unused-using-decls,moder…

### DIFF
--- a/include/libendian/EndianIStreamAdapter.h
+++ b/include/libendian/EndianIStreamAdapter.h
@@ -124,7 +124,7 @@ operator>>(libendian::EndianIStreamAdapter<T_isBigEndian, T_Stream>& is, std::ve
         return is;
     }
 
-    is.read(&vec[0], vec.size());
+    is.read(vec.data(), vec.size());
 
     return is;
 }

--- a/include/libendian/EndianOStreamAdapter.h
+++ b/include/libendian/EndianOStreamAdapter.h
@@ -116,7 +116,7 @@ EndianOStreamAdapter<T_isBigEndian, T_Stream>& operator<<(EndianOStreamAdapter<T
         return os;
     }
 
-    os.write(&vec[0], vec.size());
+    os.write(vec.data(), vec.size());
 
     return os;
 }


### PR DESCRIPTION
…nize-use-auto,performance-inefficient-vector-operation,performance-move-const-arg,readability-container-size-empty,readability-redundant-member-init,performance-noexcept-swap,readability-redundant-inline-specifier,readability-container-data-pointer